### PR TITLE
Enable publishing of migrations to enable more customization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "hmones/laravel-digest",
-    "description": ":package_description",
+    "description": "A simple package to create and send digest emails every certain period or when the amount reaches a certain threshold.",
     "license": "MIT",
     "authors": [
         {

--- a/database/migrations/2022_01_30_000000_create_digests_table.php
+++ b/database/migrations/2022_01_30_000000_create_digests_table.php
@@ -13,7 +13,7 @@ class CreateDigestsTable extends Migration
             $table->string('batch');
             $table->string('mailable');
             $table->string('frequency')->nullable();
-            $table->json('data')->nullable();
+            $table->text('data')->nullable();
             $table->timestamps();
         });
     }

--- a/src/LaravelDigestServiceProvider.php
+++ b/src/LaravelDigestServiceProvider.php
@@ -23,14 +23,11 @@ class LaravelDigestServiceProvider extends ServiceProvider
             __DIR__.'/../config/laravel-digest.php' => config_path('laravel-digest.php'),
         ], 'laravel-digest-config');
 
-        $this->app->afterResolving(Schedule::class, function (Schedule $schedule) {
-            $schedule->command('digest:send daily')->dailyAt(config('laravel-digest.frequency.daily.time'));
-            $schedule->command('digest:send weekly')->weeklyOn(config('laravel-digest.frequency.weekly.day'), config('laravel-digest.frequency.weekly.time'));
-            $schedule->command('digest:send monthly')->monthlyOn(config('laravel-digest.frequency.monthly.day'), config('laravel-digest.frequency.monthly.time'));
-            foreach (Digest::getCustomFrequencies() as $name => $cron) {
-                $schedule->command('digest:send '.$name)->cron($cron);
-            }
-        });
+        $this->publishes([
+            __DIR__.'/../database/migrations/' => database_path('migrations'),
+        ], 'laravel-digest-migrations');
+
+        $this->scheduleDigestCommands();
     }
 
     public function register(): void
@@ -43,5 +40,17 @@ class LaravelDigestServiceProvider extends ServiceProvider
     public function provides(): array
     {
         return ['laravel-digest'];
+    }
+
+    protected function scheduleDigestCommands(): void
+    {
+        $this->app->afterResolving(Schedule::class, function (Schedule $schedule) {
+            $schedule->command('digest:send daily')->dailyAt(config('laravel-digest.frequency.daily.time'));
+            $schedule->command('digest:send weekly')->weeklyOn(config('laravel-digest.frequency.weekly.day'), config('laravel-digest.frequency.weekly.time'));
+            $schedule->command('digest:send monthly')->monthlyOn(config('laravel-digest.frequency.monthly.day'), config('laravel-digest.frequency.monthly.time'));
+            foreach (Digest::getCustomFrequencies() as $name => $cron) {
+                $schedule->command('digest:send '.$name)->cron($cron);
+            }
+        });
     }
 }


### PR DESCRIPTION
Enable publishing of migrations for more customization and to support database compatibility with databases with no support to JSON